### PR TITLE
Only use the first match of xpath query result for alternative text

### DIFF
--- a/insert-alt-text/insert-alt-text.jsx
+++ b/insert-alt-text/insert-alt-text.jsx
@@ -240,7 +240,7 @@ function prepareAltTexts(doc) {
       }
       writeLog('XPath: ' + xpath, options.exportDir, options.logFilename);
       // get alt text from XML, use only first match to avoid duplicates
-      var altText = String(xml.xpath(xpath + '/@alt')[0]);
+      var altText = String(xml.xpath(xpath + '[1]/@alt'));
       var artifact = String(xml.xpath(xpath + '/@artifact'));
       if (altText.length != 0 && toBeExported) {
         writeLog('alt: ' + altText, options.exportDir, options.logFilename);
@@ -381,3 +381,4 @@ function getLinkNameForGroup(group) {
   return link;
 
 }
+

--- a/insert-alt-text/insert-alt-text.jsx
+++ b/insert-alt-text/insert-alt-text.jsx
@@ -239,7 +239,8 @@ function prepareAltTexts(doc) {
         xpath = '/links/link[@name = \'' + filename + '\']';
       }
       writeLog('XPath: ' + xpath, options.exportDir, options.logFilename);
-      var altText = String(xml.xpath(xpath + '/@alt'));
+      // get alt text from XML, use only first match to avoid duplicates
+      var altText = String(xml.xpath(xpath + '/@alt')[0]);
       var artifact = String(xml.xpath(xpath + '/@artifact'));
       if (altText.length != 0 && toBeExported) {
         writeLog('alt: ' + altText, options.exportDir, options.logFilename);
@@ -378,4 +379,5 @@ function getLinkNameForGroup(group) {
     }
   }
   return link;
+
 }


### PR DESCRIPTION
When you place multiple images in InDesign the script used to duplicate the alternative text string times the number of image placements due to the way the xpath query works. Now the result is indexd and only the first match is used to populate the 'altText' varibale.